### PR TITLE
Make it clearer that the copy icon is clickable

### DIFF
--- a/Public/css/module.css
+++ b/Public/css/module.css
@@ -36,4 +36,5 @@
     display: inline-flex;
     align-items: center;
     margin-left: 20px;
+    cursor: pointer;
 }


### PR DESCRIPTION
Just a tiny change, but the first time I saw the copy icon I wasn't sure if it's clickable because it didn't change the mouse pointer.